### PR TITLE
인증 코드들은 전부 header로 담아서 전송하도록 변경

### DIFF
--- a/source/includes/authentication/send-password-code.md.erb
+++ b/source/includes/authentication/send-password-code.md.erb
@@ -46,7 +46,7 @@ axios.request(config)
 ```
 
 
-사용자의 비밀번호를 찾기 위해 SMS 인증 코드를 전송합니다.
+사용자의 비밀번호를 찾아 변경하기 위해 SMS 인증 코드를 전송합니다.
 
 ### HTTP Request
 

--- a/source/includes/authentication/send-password-code.md.erb
+++ b/source/includes/authentication/send-password-code.md.erb
@@ -60,7 +60,7 @@ axios.request(config)
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
-| phone | string | true | 인증코드를 전송할 전화번호 |
+| phone | `string` | true | 인증코드를 전송할 전화번호 |
 
 ### Response Code
 
@@ -72,11 +72,11 @@ axios.request(config)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| from | string | 인증코드를 전송한 전화번호 |
-| to | string | 인증코드를 받은 전화번호 |
-| body | string | 인증코드 |
-| ttl | number | 인증 코드 유효 시간 (ms) |
-| createdAt | string | 인증 코드 생성 시간 |
+| from | `string` | 인증코드를 전송한 전화번호 |
+| to | `string` | 인증코드를 받은 전화번호 |
+| body | `string` | 인증코드 |
+| ttl | `number` | 인증 코드 유효 시간 (ms) |
+| createdAt | `string` | 인증 코드 생성 시간 |
 
 ### Error Code
 
@@ -84,3 +84,4 @@ axios.request(config)
 | ---- | ------- | ----------- |
 | 400 | `INVALID_PHONE_NUMBER` | 유효하지 않은 전화번호 |
 | 404 | `NOT_FOUND_USER` | 사용자를 찾을 수 없음 |
+| 409 | `ALREADY_EXISTS_VERIFICATION` | 이미 인증 코드가 발급된 경우 |

--- a/source/includes/authentication/send-verification.md.erb
+++ b/source/includes/authentication/send-verification.md.erb
@@ -88,5 +88,5 @@ axios.request(config)
 | ---- | ------- | ----------- |
 | 400 | `INVALID_PHONE_NUMBER` | 잘못된 휴대폰 번호 |
 | 400 | `ALREADY_VERIFIED_PHONE` | 이미 인증된 휴대폰 번호 |
-| 400 | `ALREADY_EXISTS_VERIFICATION` | 이미 인증 코드가 발급된 경우 |
 | 401 | `Unauthorized` | 미 로그인 상태 |
+| 409 | `ALREADY_EXISTS_VERIFICATION` | 이미 인증 코드가 발급된 경우 |

--- a/source/includes/authentication/send-verification.md.erb
+++ b/source/includes/authentication/send-verification.md.erb
@@ -64,7 +64,7 @@ axios.request(config)
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
-| phone | string | true | 인증코드를 전송할 전화번호 |
+| phone | `string` | true | 인증코드를 전송할 전화번호 |
 
 ### Response Code 
 
@@ -76,11 +76,11 @@ axios.request(config)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| from | string | 인증코드를 전송한 전화번호 |
-| to | string | 인증코드를 받은 전화번호 |
-| body | string | 인증코드 |
-| ttl | number | 인증 코드 유효 시간 (ms) |
-| createdAt | string | 인증 코드 생성 시간 |
+| from | `string` | 인증코드를 전송한 전화번호 |
+| to | `string` | 인증코드를 받은 전화번호 |
+| body | `string` | 인증코드 |
+| ttl | `number` | 인증 코드 유효 시간 (ms) |
+| createdAt | `string` | 인증 코드 생성 시간 |
 
 ### Error Code
 

--- a/source/includes/authentication/verify-code.md.erb
+++ b/source/includes/authentication/verify-code.md.erb
@@ -5,34 +5,30 @@
 ```http
 POST <%= config[:version] %>/auth/verification/check HTTP/1.1
 Host: <%= config[:host] %>
+X-Verification-Code: 747115
 Content-Type: application/json
 Authorization: Bearer {access_token}
-Content-Length: 79
+Content-Length: 32
 
 {
-    "phone": "+821093814181",
-    "code": "111111",
-    "countryCode": "KR"
+    "phone": "+821012341234"
 }
 ```
 
 ```shell
 curl --location '<%= config[:base_url] %>/auth/verification/check ' \
+--header 'X-Verification-Code: 747115' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer {access_token}' \
 --data '{
-    "phone": "+821093814181",
-    "code": "111111",
-    "countryCode": "KR"
+    "phone": "+821093814181"
 }'
 ```
 
 ```javascript
 const axios = require('axios');
 let data = JSON.stringify({
-  "phone": "+821093814181",
-  "code": "111111",
-  "countryCode": "KR"
+  "phone": "+821093814181"
 });
 
 let config = {
@@ -40,6 +36,7 @@ let config = {
   maxBodyLength: Infinity,
   url: '<%= config[:base_url] %>/auth/verification/check',
   headers: { 
+    'X-Verification-Code': '747115',
     'Content-Type': 'application/json', 
     'Authorization': 'Bearer {access_token}'
   },
@@ -56,11 +53,11 @@ axios.request(config)
 
 ```
 
-사용자에게서 인증 코드를 받아 검증합니다.
+사용자에게서 인증 코드를 받아 검증해 사용자의 권한을 업데이트합니다.
 
-회원가입할 때 사용자가 전화번호를 잘못 입력한 경우, 해당 `phone` 값으로 인증 코드를 전송할 수 있으며, 이 때 `countryCode`를 함께 전송해야 합니다.
+회원가입했을 때 사용자가 전화번호를 잘못 입력한 경우, `phone` 에 새로운 전화번호를 입력해 인증 코드를 전송할 수 있습니다.
 
-인증이 완료되면 기존 `phone`과 `countryCode`는 새로 입력된 `phone`과 `countryCode`로 대체됩니다.
+인증에 성공할 경우, 회원가입할 때 입력했던 `phone`은 새로 입력된 `phone`으로 대체됩니다.
 
 ### HTTP Request
 
@@ -70,13 +67,17 @@ axios.request(config)
 
 - `user:anonymous`
 
+### Request Header
+
+| Parameter        | Required | Description |
+| ---------------- | -------- | ----------- |
+| X-Verification-Code  | true | 인증 코드 |
+
 ### Request Body
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | phone | string | true | 인증코드를 전송한 전화번호 |
-| code | string | true | 사용자가 입력한 인증코드 |
-| countryCode | string | true | 국가코드 |
 
 ### Response Code
 
@@ -96,3 +97,4 @@ axios.request(config)
 | 400 | `ALREADY_VERIFIED_PHONE` | 이미 인증된 전화번호 |
 | 400 | `INVALID_VERIFICATION_CODE` | 유효하지 않은 인증 코드 |
 | 401 | `VERIFICATION_CODE_UNAVAILABLE_OR_EXPIRED` | 인증 코드가 존재하지 않거나 만료됨 |
+| 409 | `ALREADY_EXISTS_VERIFICATION` | 이미 인증 코드가 발급된 경우 |

--- a/source/includes/authentication/verify-password-code.md.erb
+++ b/source/includes/authentication/verify-password-code.md.erb
@@ -5,12 +5,12 @@
 ```http
 PATCH <%= config[:version] %>/auth/verification/password/check HTTP/1.1
 Host: <%= config[:host] %>
+X-Verification-Code: 123456
 Content-Type: application/json
-Content-Length: 84
+Content-Length: 58
 
 {
     "phone":"+821093814181",
-    "code": "382659",
     "password": "!Qhdans0319"
 }
 ```
@@ -18,9 +18,9 @@ Content-Length: 84
 ```shell
 curl --location --request PATCH '<%= config[:base_url] %>/auth/verification/password/check' \
 --header 'Content-Type: application/json' \
+--header 'X-Verification-Code: 123456' \
 --data '{
     "phone":"+821093814181",
-    "code": "382659",
     "password": "!Qhdans0319"
 }'
 ```
@@ -29,7 +29,6 @@ curl --location --request PATCH '<%= config[:base_url] %>/auth/verification/pass
 const axios = require('axios');
 let data = JSON.stringify({
   "phone": "+821093814181",
-  "code": "382659",
   "password": "!Qhdans0319"
 });
 
@@ -38,7 +37,8 @@ let config = {
   maxBodyLength: Infinity,
   url: '<%= config[:base_url] %>/auth/verification/password/check',
   headers: { 
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'X-Verification-Code': '123456'
   },
   data : data
 };
@@ -52,9 +52,10 @@ axios.request(config)
 });
 ```
 
-SMS 인증 코드를 받아 검증합니다.
 
-검증에 성공할 경우, 기존 사용자의 비밀번호는 새롭게 암호화된 `password`로 변경됩니다. 
+사용자의 비밀번호를 찾아 변경하기 위해 SMS 인증 코드를 받아 검증합니다.
+
+검증에 성공할 경우, 기존 사용자의 비밀번호는 `password`로 변경됩니다. 
 
 ### HTTP Request
 
@@ -64,12 +65,17 @@ SMS 인증 코드를 받아 검증합니다.
 
 - No permission required
 
+### Request Header
+
+| Parameter        | Required | Description |
+| ---------------- | -------- | ----------- |
+| X-Verification-Code  | true | 인증 코드 |
+
 ### Request Body
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | phone | string | true | 인증코드를 전송한 전화번호 |
-| code | string | true | 사용자가 입력한 인증코드 |
 | password | string | true | 비밀번호 |
 
 ### Response Code

--- a/source/includes/authentication/verify-password-code.md.erb
+++ b/source/includes/authentication/verify-password-code.md.erb
@@ -71,12 +71,14 @@ axios.request(config)
 | ---------------- | -------- | ----------- |
 | X-Verification-Code  | true | 인증 코드 |
 
+`X-Verification-Code`는 <a href="#send-pw-change-sms-code">인증 코드</a>를 사용합니다.
+
 ### Request Body
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
-| phone | string | true | 인증코드를 전송한 전화번호 |
-| password | string | true | 비밀번호 |
+| phone | `string` | true | 인증코드를 전송한 전화번호 |
+| password | `string` | true | 비밀번호 |
 
 ### Response Code
 
@@ -88,7 +90,7 @@ axios.request(config)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| success | boolean | 인증 성공 여부 |
+| success | `boolean` | 인증 성공 여부 |
 
 ### Error Code
 


### PR DESCRIPTION
잘못 기입된 에러코드 수정

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->